### PR TITLE
error handling for executeCommand and some smaller stuff

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -14,14 +14,6 @@ type clusterCheck struct {
 }
 
 func startCheckForRebootedSystem(cc clusterCheck, req request) {
-	//checkerLogger.Warn("Recieved: ", cc)
-
-	//case <-time.After(cc.Csetting.RebootCompletionCheckOffset):
-	//	checkerLogger.Info("Waking up check from time.After sleep for " + cc.Csetting.RebootCompletionCheckOffset.String())
-	//	// TODO do panic stuff
-	//	break//
-	//}
-
 	checkerLogger.Info("Starting check for rebooted system in cluster " + cc.Cluster + " with fqdn: " + cc.Fqdn)
 	successfulChecks := 0
 	for {

--- a/checker.go
+++ b/checker.go
@@ -13,14 +13,14 @@ type clusterCheck struct {
 	Cluster   string
 }
 
-func startCheckForRebootedSystem(cc clusterCheck, req request) {
+func startCheckForRebootedSystem(cc clusterCheck, req request, cs clusterSetting) {
 	checkerLogger.Info("Starting check for rebooted system in cluster " + cc.Cluster + " with fqdn: " + cc.Fqdn)
 	successfulChecks := 0
 	for {
 		command := strings.Replace(cc.Csetting.RebootCompletionCheck, "{:%fqdn%:}", cc.Fqdn, -1)
 		command = strings.Replace(command, "{:%hostname%:}", cc.Fqdn, -1)
 		command = strings.Replace(command, "{:%cluster%:}", cc.Fqdn, -1)
-		er := executeCommand(command, 5, true, checkerLogger)
+		er := executeCommand(command, 5, !cs.RaiseErrors, checkerLogger)
 		checkerLogger.Info("Check result of "+command+" is ", er.returnCode)
 
 		if er.returnCode == 0 {

--- a/checker.go
+++ b/checker.go
@@ -36,9 +36,7 @@ func startCheckForRebootedSystem(cc clusterCheck, req request) {
 		time.Sleep(cc.Csetting.RebootCompletionCheckInterval)
 	}
 	checkerLogger.Info("fqdn: " + cc.Fqdn + " seems to have successfully rebooted in cluster " + cc.Cluster)
-	mutex.Lock()
 	clusterLogger := clusterLoggers[cc.Cluster]
-	mutex.Unlock()
 	clusterLogger.Info("fqdn: " + cc.Fqdn + " seems to have successfully rebooted in cluster " + cc.Cluster)
 	triggerRebootCompletionActions(cc.Fqdn, cc.Cluster, req.Uptime, clusterLogger)
 	//deleteAckFile(cc.Fqdn, cc.Cluster)

--- a/examples.d/foobar-server.yml
+++ b/examples.d/foobar-server.yml
@@ -16,9 +16,12 @@ foobar-server:
   reboot_completion_actions:
     - ./tests/reboot_successful_action.sh {:%fqdn%:} {:%cluster%:}
   reboot_completion_panic_threshold: 3h
-  reboot_completion_panic_action: 
+  reboot_completion_panic_action:
     mail:
         - xorpaul@gmail.com
     scripts:
         - /tmp/{:%fqdn%:}_panic
   enabled: true
+  # Set raise_errors to true to cause errors to propagate and stop
+  # the processing of the cluster.
+  raise_errors: false

--- a/helper.go
+++ b/helper.go
@@ -170,11 +170,7 @@ func executeCommand(command string, timeout int, allowFail bool, logger *log.Ent
 	if msg, ok := err.(*exec.ExitError); ok { // there is error code
 		er.returnCode = msg.Sys().(syscall.WaitStatus).ExitStatus()
 	}
-	if allowFail && err != nil {
-		logger.Debug("Executing " + command + " took " + strconv.FormatFloat(duration, 'f', 5, 64) + "s")
-	} else {
-		logger.Debug("Executing " + command + " took " + strconv.FormatFloat(duration, 'f', 5, 64) + "s")
-	}
+	logger.Debug("Executing " + command + " took " + strconv.FormatFloat(duration, 'f', 5, 64) + "s")
 	if err != nil {
 		if !allowFail {
 			logger.Warn("executeCommand(): command failed: " + command + " " + err.Error() + "\nOutput: " + string(out))

--- a/v1.go
+++ b/v1.go
@@ -140,7 +140,7 @@ func restartHandlerV1(w http.ResponseWriter, r *http.Request) {
 				// because the server only inquired if it should restart
 				// which means that the previous necessary restart did happen.
 				res.Message = "No reason to restart"
-				inquireResult := checkAckFileInquire(request, res, clusterLogger)
+				inquireResult := checkAckFileInquire(request, res, clusterLogger, clusterSettings[c])
 
 				clusterLogger.Infof("inquireResult from checkAckFileInquire %+v", inquireResult)
 				if !inquireResult.InquireToRestart {


### PR DESCRIPTION
Hi,

I have made some small changes to goahead to raise an error in executeCommand, when it hits an error. The adjustments are made, so that it is backwards compatible.

I have also removed a couple mutex locks, because they were around accessing large maps, that were only written to at the start of the daemon, so that shouldn't cause any issues.

If you need me to change anything, please tell me and I will follow :)