### PR TITLE
Feature/obs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ ssl/
 .vscode/
 goahead
 .vscode/
+
+#OSC home directory
+home:*/**

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,13 @@ ssl/
 goahead
 .vscode/
 
+#Temporary Go stuff
+vendor/**
+go.sum
+
 #OSC home directory
 home:*/**
+
+#Archives and others
+*.gz
+*.xz

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ Simple service that allows or denies server / OS restarts.
 
 Client can be found here: https://github.com/xorpaul/goahead_client
 
+## Building
+
+```sh
+go mod tidy
+go build
+```
+
 ### workflow
 
 #### Client inquires or requests restart

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jlalvarez-arsys/goahead
 
-go 1.21.8
+go 1.19
 
 require (
 	github.com/fatih/color v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jlalvarez-arsys/goahead
+module github.com/xorpaul/goahead
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,17 @@
+module github.com/jlalvarez-arsys/goahead
+
+go 1.21.8
+
+require (
+	github.com/fatih/color v1.16.0
+	github.com/gorilla/mux v1.8.1
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/sirupsen/logrus v1.9.3
+	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	golang.org/x/sys v0.14.0 // indirect
+)

--- a/goahead.go
+++ b/goahead.go
@@ -42,7 +42,7 @@ func main() {
 	version := *versionFlag
 
 	if version {
-		fmt.Println("goahead version 0.0.6 Build time:", buildtime, "UTC")
+		fmt.Println("goahead version 0.0.7 Build time:", buildtime, "UTC")
 		os.Exit(0)
 	}
 

--- a/goahead.spec
+++ b/goahead.spec
@@ -12,7 +12,7 @@ Summary:        Simple service that allows or denies server / OS restarts
 Url:            https://github.com/jlalvarez-arsys/goahead
 Source0:         goahead_client-%{version}.tar.gz
 Source1:         vendor.tar.gz
-BuildRequires:  (go or go1.19)
+BuildRequires:  (go or go1.19 or golang or golang-1.19)
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description

--- a/goahead.spec
+++ b/goahead.spec
@@ -4,7 +4,7 @@
 # -- Copyright omitted --
 
 Name:           goahead
-Version:        0.0.6
+Version:        0.0.7
 Release:        0
 License:        Apache-2.0
 Group:          System/Monitoring

--- a/goahead.spec
+++ b/goahead.spec
@@ -12,7 +12,7 @@ Summary:        Simple service that allows or denies server / OS restarts
 Url:            https://github.com/jlalvarez-arsys/goahead
 Source0:         goahead-%{version}.tar.gz
 Source1:         vendor.tar.gz
-BuildRequires:  go1.22
+BuildRequires:  go
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description

--- a/goahead.spec
+++ b/goahead.spec
@@ -3,14 +3,14 @@
 #
 # -- Copyright omitted --
 
-Name:           goahead
+Name:           goahead_client
 Version:        0.0.1
 Release:        0
 License:        Apache-2.0
 Group:          System/Monitoring
 Summary:        Simple service that allows or denies server / OS restarts
 Url:            https://github.com/jlalvarez-arsys/goahead
-Source0:         goahead-%{version}.tar.gz
+Source0:         goahead_client-%{version}.tar.gz
 Source1:         vendor.tar.gz
 BuildRequires:  (go or go1.19)
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/goahead.spec
+++ b/goahead.spec
@@ -12,7 +12,7 @@ Summary:        Simple service that allows or denies server / OS restarts
 Url:            https://github.com/jlalvarez-arsys/goahead
 Source0:         goahead-%{version}.tar.gz
 Source1:         vendor.tar.gz
-BuildRequires:  go
+BuildRequires:  go1.22
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description

--- a/goahead.spec
+++ b/goahead.spec
@@ -1,0 +1,37 @@
+#
+# spec file for package goahead
+#
+# -- Copyright omitted --
+
+Name:           goahead
+Version:        0.0.1
+Release:        0
+License:        Apache-2.0
+Group:          Administration
+Summary:        Simple service that allows or denies server / OS restarts
+Url:            https://github.com/jlalvarez-arsys/goahead
+Source0:         goahead-%{version}.tar.gz
+Source1:         vendor.tar.gz
+BuildRequires:  go
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+
+%description
+Simple service that allows or denies server / OS restarts
+
+%prep
+%setup -q -n %{name}-%{version}
+# unpack Source1 after changing directory
+%setup -q -a 1
+
+%build
+go build -mod=vendor -o %{name}
+
+%install
+install -D -m 0755 %{name} "%{buildroot}/usr/bin/%{name}"
+
+%files
+%defattr(-,root,root,-)
+%doc README.md LICENSE
+%{_bindir}/*
+
+%changelog

--- a/goahead.spec
+++ b/goahead.spec
@@ -7,12 +7,12 @@ Name:           goahead
 Version:        0.0.1
 Release:        0
 License:        Apache-2.0
-Group:          Administration
+Group:          System/Monitoring
 Summary:        Simple service that allows or denies server / OS restarts
 Url:            https://github.com/jlalvarez-arsys/goahead
 Source0:         goahead-%{version}.tar.gz
 Source1:         vendor.tar.gz
-BuildRequires:  go
+BuildRequires:  (go or go1.19)
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description

--- a/goahead.spec
+++ b/goahead.spec
@@ -3,16 +3,21 @@
 #
 # -- Copyright omitted --
 
-Name:           goahead_client
-Version:        0.0.1
+Name:           goahead
+Version:        0.0.6
 Release:        0
 License:        Apache-2.0
 Group:          System/Monitoring
 Summary:        Simple service that allows or denies server / OS restarts
 Url:            https://github.com/jlalvarez-arsys/goahead
-Source0:         goahead_client-%{version}.tar.gz
+Source0:         %{name}-%{version}.tar.gz
 Source1:         vendor.tar.gz
-BuildRequires:  (go or go1.19 or golang or golang-1.19)
+%if 0%{?suse_version}
+BuildRequires:  (go or go1.19)
+%else
+BuildRequires:  (go or go1.19)
+%endif
+
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description


### PR DESCRIPTION
# Added RPM specfile

For better building and deployment on enterprise linux servers, an RPM spec file `goahead.spec` was added as to allow build services to build GoAhead and generate RPM packages.

For aiding builds on build services, `go.mod` was required so it was created.

# Bumped version to 0.0.7

Bug reported on commit ["fix bug with non-restarting servers and always write reported uptime to the AckFile"](https://github.com/xorpaul/goahead/commit/e72bef0853cc9e31d5a1df34ca94abefdf5721fe) managed to be triggered on our deployments, To fix the issue we starting building against master but I suggest a new version be tagged on your upstream repository.